### PR TITLE
오류 처리

### DIFF
--- a/src/main/java/com/woodongleee/src/teamMatch/TeamMatchProvider.java
+++ b/src/main/java/com/woodongleee/src/teamMatch/TeamMatchProvider.java
@@ -79,7 +79,7 @@ public class TeamMatchProvider {
             List<GetApplyTeamRes> getApplyTeamResList = teamMatchDao.getApplyTeamRes(teamScheduleIdx);
             return getApplyTeamResList;
         } catch(BaseException e){
-            throw e;
+            throw new BaseException(BaseResponseStatus.DATABASE_ERROR);
         }catch(Exception exception){
             throw new BaseException(BaseResponseStatus.DATABASE_ERROR);
         }
@@ -94,7 +94,7 @@ public class TeamMatchProvider {
             int userIdx = teamMatchDao.selectUserIdxByTeamScheduleIdx(teamScheduleIdx);
             return userIdx;
         }catch(BaseException e){
-            throw e;
+            throw new BaseException(BaseResponseStatus.DATABASE_ERROR);
         }catch(Exception exception){
             throw new BaseException(BaseResponseStatus.DATABASE_ERROR);
         }
@@ -125,7 +125,7 @@ public class TeamMatchProvider {
             List<GetTeamMatchPostRes> getTeamMatchPostResList = teamMatchDao.getTeamMatchPosts(userIdxByJwt, town, startTime, endTime);
             return getTeamMatchPostResList;
         } catch(BaseException e){
-            throw e;
+            throw new BaseException(BaseResponseStatus.DATABASE_ERROR);
         }catch(Exception exception){
             throw new BaseException(BaseResponseStatus.DATABASE_ERROR);
         }

--- a/src/main/java/com/woodongleee/src/teamMatch/TeamMatchService.java
+++ b/src/main/java/com/woodongleee/src/teamMatch/TeamMatchService.java
@@ -113,7 +113,7 @@ public class TeamMatchService {
                 throw new BaseException(BaseResponseStatus.DELETE_FAIL_POST);
             }
         }catch(BaseException e){
-            throw e;
+            throw new BaseException(BaseResponseStatus.DATABASE_ERROR);
         }catch(Exception exception){
             throw new BaseException(BaseResponseStatus.DATABASE_ERROR);
         }
@@ -141,7 +141,7 @@ public class TeamMatchService {
 
             teamMatchDao.applyTeamMatch(userIdxByJwt, matchPostIdx);
         }catch(BaseException e){
-            throw e;
+            throw new BaseException(BaseResponseStatus.DATABASE_ERROR);
         }catch(Exception exception){
             throw new BaseException(BaseResponseStatus.DATABASE_ERROR);
         }
@@ -173,7 +173,7 @@ public class TeamMatchService {
 
             teamMatchDao.cancelApplyTeamMatch(userIdxByJwt, matchPostIdx);
         } catch (BaseException e) {
-            throw e;
+            throw new BaseException(BaseResponseStatus.DATABASE_ERROR);
         } catch (Exception exception) {
             throw new BaseException(BaseResponseStatus.DATABASE_ERROR);
         }
@@ -201,6 +201,7 @@ public class TeamMatchService {
             }
             if(doNotExistTeamMatch(postGameResultReq.getTeamScheduleIdx())){
                 throw new BaseException(BaseResponseStatus.SCHEDULE_DOES_NOT_EXIST);
+                //throw new BaseResponse<>(BaseResponseStatus.SCHEDULE_DOES_NOT_EXIST); 아닌가..?
             }
             if(validResultAccessTime(postGameResultReq.getTeamScheduleIdx())){
                 return new BaseResponse<>(BaseResponseStatus.GAME_RESULT_PERIOD_ERROR);
@@ -250,7 +251,7 @@ public class TeamMatchService {
 
             teamMatchDao.rejectTeamMatchApply(matchApplyIdx);
         } catch (BaseException e) {
-            throw e;
+            throw new BaseException(BaseResponseStatus.DATABASE_ERROR);
         } catch (Exception exception) {
             throw new BaseException(BaseResponseStatus.DATABASE_ERROR);
         }
@@ -282,7 +283,7 @@ public class TeamMatchService {
             int awayTeamIdx = teamMatchDao.selectTeamIdxByUserIdx(awayLeaderUserIdx);
             teamMatchDao.acceptTeamMatchApply(matchApplyIdx, matchPostIdx, teamScheduleIdx, awayTeamIdx);
         } catch (BaseException e) {
-            throw e;
+            throw new BaseException(BaseResponseStatus.DATABASE_ERROR);
         } catch (Exception exception) {
             throw new BaseException(BaseResponseStatus.DATABASE_ERROR);
         }
@@ -332,7 +333,7 @@ public class TeamMatchService {
     }
 
     public String selectStartTime(int teamScheduleIdx){
-        String start = null;
+        String start = "2000-01-01 00:00:00";
         try {
             start = teamMatchDao.selectStartTime(teamScheduleIdx);
             return start;
@@ -374,7 +375,7 @@ public class TeamMatchService {
     }
 
     public boolean startTimeCompareToNow(Calendar startTime, Calendar now){
-        return startTime.compareTo(now)==-1;
+        return now.compareTo(startTime)==-1;
     }
 
     // 경기가 종료된 후에 경기 결과 추가가 가능하다.
@@ -389,7 +390,7 @@ public class TeamMatchService {
     }
 
     public String selectEndTime(int teamScheduleIdx){
-        String end = null;
+        String end = "9999-01-01 00:00:00";
         try {
             end = teamMatchDao.selectEndTime(teamScheduleIdx);
             return end;
@@ -400,7 +401,7 @@ public class TeamMatchService {
     }
 
     public boolean nowCompareToEndTime(Calendar now, Calendar endTime){
-        return now.compareTo(endTime)==-1;
+        return endTime.compareTo(now)==-1;
     }
 
     public boolean intEqualsInt(int int1, int int2){


### PR DESCRIPTION
1. 예외를 던질 때, 예외가 발생한 이유에 대한 설명을 담아 던졌다.
2. 경기 시작 시간을 조회할 때, 초기값을 null로 두었다.
    그러면 try-catch에서 에러가 발생하면 해당 함수는 null값이 리턴된다.
    그래서 로직을 수행하는데 영향을 미치지 않는 초기값으로 지정해두었다.
+) startTimeCompareToNow()와 nowCompareToEndTime()에서 잘못된 코드 발견하여 고침.