### PR TITLE
클래스

### DIFF
--- a/src/main/java/com/woodongleee/src/teamMatch/TeamMatchController.java
+++ b/src/main/java/com/woodongleee/src/teamMatch/TeamMatchController.java
@@ -17,13 +17,14 @@ import java.util.List;
 @RequestMapping("/team-match")
 public class TeamMatchController {
 
-    final Logger logger = LoggerFactory.getLogger(this.getClass());
+    public static final int POST_LENGTH_MAX = 500;
+    public static final int VALID_SCORE_MIN = 0;
 
     private final TeamMatchProvider teamMatchProvider;
     private final TeamMatchService teamMatchService;
     private final JwtService jwtService;
-    public static final int POST_LENGTH_MAX = 500;
-    public static final int VALID_SCORE_MIN = 0;
+
+    final Logger logger = LoggerFactory.getLogger(this.getClass());
 
     public TeamMatchController(TeamMatchProvider teamMatchProvider, TeamMatchService teamMatchService, JwtService jwtService) {
         this.teamMatchProvider = teamMatchProvider;

--- a/src/main/java/com/woodongleee/src/teamMatch/TeamMatchProvider.java
+++ b/src/main/java/com/woodongleee/src/teamMatch/TeamMatchProvider.java
@@ -15,9 +15,10 @@ import java.util.List;
 @Service
 public class TeamMatchProvider {
 
+    public static final int DO_NOT_EXIST = 0;
+
     private final TeamMatchDao teamMatchDao;
     private final JwtService jwtService;
-    public static final int DO_NOT_EXIST = 0;
 
     final Logger logger = LoggerFactory.getLogger(this.getClass());
 

--- a/src/main/java/com/woodongleee/src/teamMatch/TeamMatchService.java
+++ b/src/main/java/com/woodongleee/src/teamMatch/TeamMatchService.java
@@ -19,12 +19,13 @@ import java.util.Date;
 @Service
 public class TeamMatchService {
 
-    final Logger logger = LoggerFactory.getLogger(this.getClass());
+    public static final int DO_NOT_EXIST = 0;
 
     private final TeamMatchDao teamMatchDao;
     private final TeamMatchProvider teamMatchProvider;
     private final JwtService jwtService;
-    public static final int DO_NOT_EXIST = 0;
+
+    final Logger logger = LoggerFactory.getLogger(this.getClass());
 
 
     @Autowired


### PR DESCRIPTION
클래스를 정의하는 표준 자바 관례에 따라 변수의 순서를 
정적 공개 상수 > 정적 비공개 변수 > 비공개 인스턴스 변수 > 공개 변수 
순으로 변경해주었다.